### PR TITLE
Lazy evaluation when drones collide

### DIFF
--- a/Simulation/GridEnvironment/GWSimulation.cs
+++ b/Simulation/GridEnvironment/GWSimulation.cs
@@ -105,7 +105,8 @@ public class GWSim(ILogger logger) : IGWSimulation
                     !d1.Value.Destroyed &&
                     !d2.Value.Destroyed
                 ))
-            .Select(e => e.Value);
+            .Select(e => e.Value)
+            .ToList();
 
         foreach (var drone in colliding_drones)
             drone.Destroyed = true;


### PR DESCRIPTION
Hans Hüttel loved lazy evaluation the way poets love silence. Why compute now, he’d say, when later is so much more elegant?

Then a bug surfaced in production—an error born early but revealed far too late, buried beneath layers of deferred promises.

At 3 a.m., staring at a stack trace that pointed everywhere and nowhere, Hans quietly switched it off.

-Poul

closes #20 