### PR TITLE
fix: Remove unused velocity in incoming NewRequests

### DIFF
--- a/Simulation.Lib/GW/GWSimulationServer.cs
+++ b/Simulation.Lib/GW/GWSimulationServer.cs
@@ -113,8 +113,7 @@ public class GWSimulationServer : SimulationService.SimulationServiceBase, IDisp
         var state = await newSim.New(
             request.Map,
             (int)request.EvaderCount,
-            (int)request.PursuerCount,
-            (int)request.DroneVelocity
+            (int)request.PursuerCount
         );
 
         return new NewResponse

--- a/Simulation.Lib/GW/IGWSimulation.cs
+++ b/Simulation.Lib/GW/IGWSimulation.cs
@@ -7,5 +7,5 @@ public interface IGWSimulation
     Task<State> Reset();
     Task Close();
     Task<State> DoStep(List<DroneAction> actions);
-    Task<State> New(MapSpec mapSpec, int evaders, int pursuers, int drone_velocity);
+    Task<State> New(MapSpec mapSpec, int evaders, int pursuers);
 }

--- a/Simulation/GW/GWSimulation.cs
+++ b/Simulation/GW/GWSimulation.cs
@@ -42,12 +42,12 @@ public class GWSimulation(ILogger logger, IDroneSpawner droneSpawner, IMapSpawne
         return state;
     }
 
-    public async Task<State> New(MapSpec mapSpec, int evaders, int pursuers, int drone_velocity)
+    public async Task<State> New(MapSpec mapSpec, int evaders, int pursuers)
     {
         if (_instance is not null)
             throw new Exception("Attempted override an existing simulation!");
 
-        var (state, newInstance) = await CreateNewSimulation(pursuers, evaders, drone_velocity, mapSpec);
+        var (state, newInstance) = await CreateNewSimulation(pursuers, evaders, mapSpec);
         _instance = newInstance;
 
         return state;
@@ -68,20 +68,20 @@ public class GWSimulation(ILogger logger, IDroneSpawner droneSpawner, IMapSpawne
         _instance?.Dispose();
     }
 
-    private async Task<(State, GWSimulationInstance)> CreateNewSimulation(int defenders, int attackers, int velocity, MapSpec mapSpec)
+    private async Task<(State, GWSimulationInstance)> CreateNewSimulation(int defenders, int attackers, MapSpec mapSpec)
     {
         List<GWDrone> defenderDrones = new(defenders);
         List<GWDrone> attackerDrones = new(attackers);
 
         for (int i = 0; i < defenders; i++)
         {
-            var d = _droneSpawner.SpawnDrone(i, velocity, false);
+            var d = _droneSpawner.SpawnDrone(i, false);
             defenderDrones.Add(d);
         }
 
         for (int i = defenders; i < attackers + defenders; i++)
         {
-            var a = _droneSpawner.SpawnDrone(i, velocity, true);
+            var a = _droneSpawner.SpawnDrone(i, true);
             attackerDrones.Add(a);
         }
 

--- a/Simulation/Services/DroneSpawner.cs
+++ b/Simulation/Services/DroneSpawner.cs
@@ -8,7 +8,7 @@ public class DroneSpawner : IDroneSpawner
     private readonly PackedScene _droneDefenderScene = GD.Load<PackedScene>("res://gw_drone.tscn");
     private readonly PackedScene _droneAttackerScene = GD.Load<PackedScene>("res://gw_drone_evader.tscn");
 
-    public GWDrone SpawnDrone(int id, int velocity, bool isAttacker)
+    public GWDrone SpawnDrone(int id, bool isAttacker)
     {
         PackedScene scene;
         if (isAttacker)

--- a/Simulation/Services/IDroneSpawner.cs
+++ b/Simulation/Services/IDroneSpawner.cs
@@ -4,5 +4,5 @@ namespace Simulation.Services;
 
 public interface IDroneSpawner
 {
-    GWDrone SpawnDrone(int id, int velocity, bool isAttacker);
+    GWDrone SpawnDrone(int id, bool isAttacker);
 }


### PR DESCRIPTION
I noticed velocity is a parameter of NewRequest of the NGW service. This is not intentional as each action of a drone defines the velocity, not at simulation instantiation.